### PR TITLE
v0.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 
-project ("sdl2-hyper-sonic-drivers" VERSION 0.10.0 DESCRIPTION "SDL2 based Hyper-Sonic Drivers for emulating old soundcards")
+project ("sdl2-hyper-sonic-drivers" VERSION 0.11.0 DESCRIPTION "SDL2 based Hyper-Sonic Drivers for emulating old soundcards")
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ At the moment the only implemented emulators are OPL chips.
 
 ### Adlib/Sound Blaster PRO 2.0 chips
 - [x] Mame OPL2
-- [/] Mame OPL3
+- [x] Mame OPL3
 - [x] DosBox OPL2
 - [x] DosBox Dual OPL2
 - [x] DosBox OPL3

--- a/sdl2-hyper-sonic-drivers/CMakeLists.txt
+++ b/sdl2-hyper-sonic-drivers/CMakeLists.txt
@@ -39,7 +39,9 @@ install(
 install(DIRECTORY
     src/
     DESTINATION static/include
-    FILES_MATCHING PATTERN "*.hpp"
+    FILES_MATCHING
+        PATTERN "*.hpp"
+        PATTERN "*.h"
 )
 
 ## NOTE: very error prone in this way...

--- a/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
+++ b/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
@@ -31,12 +31,13 @@ void adl_test(const OplEmulator emu, const OplType type, std::shared_ptr<audio::
         return;
 
     auto adlFile = std::make_shared<ADLFile>(filename);
-    ADLDriver adlDrv(opl, adlFile);
+    ADLDriver adlDrv(opl, audio::mixer::eChannelGroup::Music);
+    adlDrv.setADLFile(adlFile);
     adlDrv.play(track, 0xFF);
 
-    while (!mixer->isReady()) {
-        spdlog::info("mixer not ready yet..");
-        delayMillis(100);
+    if(!mixer->isReady()) {
+        spdlog::error("mixer not ready yet..");
+        return;
     }
 
     do

--- a/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
+++ b/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
@@ -38,12 +38,11 @@ void adl_test(const OplEmulator emu, const OplType type, std::shared_ptr<audio::
         spdlog::info("mixer not ready yet..");
         delayMillis(100);
     }
-
+    mixer->setMasterVolume(audio::mixer::Mixer_max_volume);
     do
     {
         //spdlog::info("is playing");
-        delayMillis(1000);
-
+        delayMillis(150);
     } while (adlDrv.isPlaying());
 }
 

--- a/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
+++ b/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
@@ -42,7 +42,7 @@ void adl_test(const OplEmulator emu, const OplType type, std::shared_ptr<audio::
     do
     {
         //spdlog::info("is playing");
-        delayMillis(150);
+        delayMillis(1000);
     } while (adlDrv.isPlaying());
 }
 

--- a/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
+++ b/sdl2-hyper-sonic-drivers/examples/adl-example.cpp
@@ -38,7 +38,7 @@ void adl_test(const OplEmulator emu, const OplType type, std::shared_ptr<audio::
         spdlog::info("mixer not ready yet..");
         delayMillis(100);
     }
-    mixer->setMasterVolume(audio::mixer::Mixer_max_volume);
+
     do
     {
         //spdlog::info("is playing");

--- a/sdl2-hyper-sonic-drivers/examples/mid-example.h
+++ b/sdl2-hyper-sonic-drivers/examples/mid-example.h
@@ -49,7 +49,7 @@ void scummvm_mid_test(const OplEmulator emu, const OplType type, const std::shar
         return;
 
     const bool isOpl3 = type == OplType::OPL3;
-    auto midi_device = std::make_shared<drivers::midi::devices::ScummVM>(opl, isOpl3, audio::mixer::eChannelGroup::Music, 255, 0);
+    auto midi_device = std::make_shared<drivers::midi::devices::ScummVM>(opl, isOpl3, audio::mixer::eChannelGroup::Music);
     drivers::MIDDriver midDrv(/*mixer,*/ midi_device);
 
     spdlog::info("playing midi OPL3={}...", isOpl3);
@@ -64,14 +64,16 @@ void mid_test(const OplEmulator emu, const OplType type, const std::shared_ptr<a
     switch (type)
     {
         using enum OplType;
+        using namespace drivers::midi;
+
     case OPL2:
-        midi_device = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
+        midi_device = make_device<devices::Adlib>(mixer, op2file.getBank(), audio::mixer::eChannelGroup::Music, emu);
         break;
     case DUAL_OPL2:
-        midi_device = std::make_shared<drivers::midi::devices::SbPro>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
+        midi_device = make_device<devices::SbPro>(mixer, op2file.getBank(), audio::mixer::eChannelGroup::Music, emu);
         break;
     case OPL3:
-        midi_device = std::make_shared<drivers::midi::devices::SbPro2>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
+        midi_device = make_device<devices::SbPro2>(mixer, op2file.getBank(), audio::mixer::eChannelGroup::Music, emu);
         break;
     default:
         throw std::runtime_error("?");

--- a/sdl2-hyper-sonic-drivers/examples/mid-example.h
+++ b/sdl2-hyper-sonic-drivers/examples/mid-example.h
@@ -49,7 +49,7 @@ void scummvm_mid_test(const OplEmulator emu, const OplType type, const std::shar
         return;
 
     const bool isOpl3 = type == OplType::OPL3;
-    auto midi_device = std::make_shared<drivers::midi::devices::ScummVM>(opl, isOpl3);
+    auto midi_device = std::make_shared<drivers::midi::devices::ScummVM>(opl, isOpl3, audio::mixer::eChannelGroup::Music, 255, 0);
     drivers::MIDDriver midDrv(/*mixer,*/ midi_device);
 
     spdlog::info("playing midi OPL3={}...", isOpl3);
@@ -65,13 +65,13 @@ void mid_test(const OplEmulator emu, const OplType type, const std::shared_ptr<a
     {
         using enum OplType;
     case OPL2:
-        midi_device = std::make_shared<drivers::midi::devices::Adlib>(mixer, op2file.getBank(), emu);
+        midi_device = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
         break;
     case DUAL_OPL2:
-        midi_device = std::make_shared<drivers::midi::devices::SbPro>(mixer, op2file.getBank(), emu);
+        midi_device = std::make_shared<drivers::midi::devices::SbPro>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
         break;
     case OPL3:
-        midi_device = std::make_shared<drivers::midi::devices::SbPro2>(mixer, op2file.getBank(), emu);
+        midi_device = std::make_shared<drivers::midi::devices::SbPro2>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2file.getBank(), emu);
         break;
     default:
         throw std::runtime_error("?");

--- a/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
+++ b/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
@@ -503,10 +503,43 @@ int midi_adlib_xmi()
     return 0;
 }
 
+void testMultiOpl()
+{
+    using hardware::opl::OplEmulator;
+    using hardware::opl::OplType;
+    using audio::mixer::eChannelGroup;
+    using utils::ILogger;
+
+    ILogger::instance->setLevelAll(ILogger::eLevel::Info);
+
+    auto mixer = audio::make_mixer<audio::sdl2::Mixer>(8, 44100, 1024);
+    if (!mixer->init())
+        std::cerr << "can't init mixer";
+
+    auto opl_a = hardware::opl::OPLFactory::create(OplEmulator::AUTO, OplType::OPL2, mixer);
+    auto opl_b = hardware::opl::OPLFactory::create(OplEmulator::AUTO, OplType::OPL2, mixer);
+
+    auto af = std::make_shared< files::westwood::ADLFile>("test/fixtures/DUNE0.ADL");
+    auto drv1 = drivers::westwood::ADLDriver(opl_a, eChannelGroup::Music);
+    drv1.setADLFile(af);
+    auto drv2 = drivers::westwood::ADLDriver(opl_b, eChannelGroup::Sfx);
+    drv2.setADLFile(af);
+
+    std::cout << af->getNumTracks() << std::endl;
+
+    drv2.play(2);
+    utils::delayMillis(2000);
+    drv1.play(4);
+
+    while(drv1.isPlaying() || drv2.isPlaying())
+        utils::delayMillis(1000);
+}
+
 
 int main(int argc, char* argv[])
 {
-    newMixerTest();
+    //newMixerTest();
+    testMultiOpl();
     return 0;
     //sdlMixer();
     //SDL_Delay(100);

--- a/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
+++ b/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
@@ -342,7 +342,7 @@ int midi_adlib()
     //std::shared_ptr<files::MIDFile> midFile = std::make_shared<files::MIDFile>("test/fixtures/MI_intro.mid");
     auto midFile = std::make_shared<files::MIDFile>("test/fixtures/midifile_sample.mid");
     auto midi = midFile->getMIDI();
-    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, true);
+    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, true, audio::mixer::eChannelGroup::Music, 255, 0);
     drivers::MIDDriver midDrv(scumm_midi);
 
 
@@ -372,7 +372,7 @@ int midi_adlib_mus_file_CONCURRENCY_ERROR_ON_SAME_DEVICE()
     auto midFile = std::make_shared<files::MIDFile>("test/fixtures/MI_intro.mid");
     auto musFile = std::make_shared<files::dmx::MUSFile>("test/fixtures/D_E1M1.MUS");
     auto midi = musFile->getMIDI();
-    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false);
+    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false, audio::mixer::eChannelGroup::Music, 255, 0);
     //spdlog::info("isAquired: {}", scumm_midi->isAcquired());
     drivers::MIDDriver midDrv(scumm_midi);
     // TODO: declare a same driver with the device shouldn't be possible.
@@ -422,7 +422,7 @@ int midi_adlib_mus_op2_file()
         if (opl.get() == nullptr)
             return -1;
 
-        auto adlib_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, op2File->getBank(), emu);
+        auto adlib_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File->getBank(), emu);
         drivers::MIDDriver midDrv(adlib_midi);
         //spdlog::info("playing midi (OPL2) D_E1M1.MUS...");
         midDrv.play(midi);
@@ -434,7 +434,7 @@ int midi_adlib_mus_op2_file()
             utils::delayMillis(1000);
     }
     {
-        auto sbpro_midi = std::make_shared<drivers::midi::devices::SbPro2>(mixer, op2File->getBank(), emu);
+        auto sbpro_midi = std::make_shared<drivers::midi::devices::SbPro2>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File->getBank(), emu);
         drivers::MIDDriver midDrv(sbpro_midi);
 
         //spdlog::info("playing midi (OPL3) D_E1M1.MUS...");
@@ -486,9 +486,9 @@ int midi_adlib_xmi()
     auto midi = std::make_shared<audio::MIDI>(audio::midi::MIDI_FORMAT::SINGLE_TRACK, 1, m->division);
     midi->addTrack(m->getTrack(0));
     
-    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false);
+    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false, audio::mixer::eChannelGroup::Music, 255, 0);
     files::dmx::OP2File op2File("test/fixtures/GENMIDI.OP2");
-    auto opl_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, op2File.getBank(), emu);
+    auto opl_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File.getBank(), emu);
     //drivers::MIDDriver midDrv(mixer, scumm_midi);
     drivers::MIDDriver midDrv(opl_midi);
 

--- a/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
+++ b/sdl2-hyper-sonic-drivers/sdl2-hyper-sonic-drivers.cpp
@@ -342,7 +342,7 @@ int midi_adlib()
     //std::shared_ptr<files::MIDFile> midFile = std::make_shared<files::MIDFile>("test/fixtures/MI_intro.mid");
     auto midFile = std::make_shared<files::MIDFile>("test/fixtures/midifile_sample.mid");
     auto midi = midFile->getMIDI();
-    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, true, audio::mixer::eChannelGroup::Music, 255, 0);
+    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, true, audio::mixer::eChannelGroup::Music);
     drivers::MIDDriver midDrv(scumm_midi);
 
 
@@ -422,7 +422,7 @@ int midi_adlib_mus_op2_file()
         if (opl.get() == nullptr)
             return -1;
 
-        auto adlib_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File->getBank(), emu);
+        auto adlib_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, op2File->getBank(), audio::mixer::eChannelGroup::Music, emu);
         drivers::MIDDriver midDrv(adlib_midi);
         //spdlog::info("playing midi (OPL2) D_E1M1.MUS...");
         midDrv.play(midi);
@@ -434,7 +434,7 @@ int midi_adlib_mus_op2_file()
             utils::delayMillis(1000);
     }
     {
-        auto sbpro_midi = std::make_shared<drivers::midi::devices::SbPro2>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File->getBank(), emu);
+        auto sbpro_midi = std::make_shared<drivers::midi::devices::SbPro2>(mixer, op2File->getBank(), audio::mixer::eChannelGroup::Music, emu);
         drivers::MIDDriver midDrv(sbpro_midi);
 
         //spdlog::info("playing midi (OPL3) D_E1M1.MUS...");
@@ -486,9 +486,9 @@ int midi_adlib_xmi()
     auto midi = std::make_shared<audio::MIDI>(audio::midi::MIDI_FORMAT::SINGLE_TRACK, 1, m->division);
     midi->addTrack(m->getTrack(0));
     
-    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false, audio::mixer::eChannelGroup::Music, 255, 0);
+    auto scumm_midi = std::make_shared<drivers::midi::devices::ScummVM>(opl, false, audio::mixer::eChannelGroup::Music);
     files::dmx::OP2File op2File("test/fixtures/GENMIDI.OP2");
-    auto opl_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, audio::mixer::eChannelGroup::Music, 255, 0, op2File.getBank(), emu);
+    auto opl_midi = std::make_shared<drivers::midi::devices::Adlib>(mixer, op2File.getBank(), audio::mixer::eChannelGroup::Music, emu);
     //drivers::MIDDriver midDrv(mixer, scumm_midi);
     drivers::MIDDriver midDrv(opl_midi);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IMixer.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IMixer.hpp
@@ -32,8 +32,7 @@ namespace HyperSonicDrivers::audio
             const mixer::eChannelGroup group,
             const std::shared_ptr<IAudioStream>& stream,
             const uint8_t vol,
-            const int8_t pan,
-            const bool reverseStereo
+            const int8_t pan
         ) = 0;
 
         virtual void suspend() noexcept = 0;
@@ -73,11 +72,17 @@ namespace HyperSonicDrivers::audio
         inline uint8_t getMasterVolume() const noexcept { return m_master_volume; };
 
         virtual void setMasterVolume(const uint8_t master_volume) noexcept = 0;
+        
+        inline void toggleReverseStereo() noexcept { m_reverseStereo = !m_reverseStereo; };
 
         const uint8_t max_channels;
     protected:
         std::array<mixer::channelGroupSettings_t, mixer::eChannelGroup_size> m_group_settings;
-        bool m_ready = false;
+        bool m_ready = false; // TODO: not really useful if not used anywhere else except init.
+                              //       unless remove init method and do it in the constructor
+                              //       and then check if it is ready before use the mixer
+                              //       otherwise can just be removed.
+        bool m_reverseStereo = false;
         const uint32_t m_sampleRate;
         const uint16_t m_samples;
         const uint8_t m_bitsDepth = 16; // forced to be 16-bits for now

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IMixer.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IMixer.hpp
@@ -65,10 +65,14 @@ namespace HyperSonicDrivers::audio
         uint8_t getChannelGroupVolume(const mixer::eChannelGroup group) const noexcept;
         void setChannelGroupVolume(const mixer::eChannelGroup group, const uint8_t volume) noexcept;
 
+
         // TODO: these 3 methods are useless if those 3 vars are consts...
         inline uint32_t getOutputRate() const noexcept { return m_sampleRate; };
         inline uint16_t getBufferSize() const noexcept { return m_samples; };
         inline uint8_t getBitsDepth() const noexcept { return m_bitsDepth; };
+        inline uint8_t getMasterVolume() const noexcept { return m_master_volume; };
+
+        virtual void setMasterVolume(const uint8_t master_volume) noexcept = 0;
 
         const uint8_t max_channels;
     protected:
@@ -77,6 +81,7 @@ namespace HyperSonicDrivers::audio
         const uint32_t m_sampleRate;
         const uint16_t m_samples;
         const uint8_t m_bitsDepth = 16; // forced to be 16-bits for now
+        uint8_t m_master_volume = mixer::Mixer_max_volume;
     };
 
     template<class T, typename... Args>

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
@@ -112,12 +112,13 @@ namespace HyperSonicDrivers::audio::mixer
             return;
         }
 
+        constexpr float ch_max_vol = static_cast<float>(mixer::Channel_max_volume);
         const uint16_t vol = m_volume * m_mixer.getChannelGroupVolume(m_group);
         const float pan = (127.5f + m_pan) / 255.0f;
         // TODO: create different selectable pan laws
         // -3dB pan law
-        m_volL = sqrt(1 - pan) * vol / mixer::Channel_max_volume;
-        m_volR = sqrt(pan) * vol / mixer::Channel_max_volume;;
+        m_volL = static_cast<uint16_t>(std::round(sqrt(1 - pan) * vol / ch_max_vol));
+        m_volR = static_cast<uint16_t>(std::round(sqrt(pan) * vol / ch_max_vol));
 
         // adjust for master volume
         const auto m_vol = m_mixer.getMasterVolume();

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
@@ -113,27 +113,15 @@ namespace HyperSonicDrivers::audio::mixer
         }
 
         const uint16_t vol = m_volume * m_mixer.getChannelGroupVolume(m_group);
-        if (m_pan < 0)
-        {
-            // left linear pan
-            m_volL = vol / mixer::Channel_max_volume;
-            m_volR = ((127 + m_pan) * vol) / (mixer::Channel_max_volume * 127);
-        }
-        else if (m_pan > 0)
-        {
-            // right linear pan
-            m_volL = ((127 + m_pan) * vol) / (mixer::Channel_max_volume * 127);
-            m_volR = vol / mixer::Channel_max_volume;
-        }
-        else
-        {
-            m_volR = m_volL = vol / mixer::Channel_max_volume;
-        }
+        const float pan = (127.5f + m_pan) / 255.0f;
+        // TODO: create different selectable pan laws
+        // -3dB pan law
+        m_volL = sqrt(1 - pan) * vol / mixer::Channel_max_volume;
+        m_volR = sqrt(pan) * vol / mixer::Channel_max_volume;;
 
         // adjust for master volume
         const auto m_vol = m_mixer.getMasterVolume();
         m_volL = ((m_volL * m_vol) / mixer::Mixer_max_volume);
         m_volR = ((m_volR * m_vol) / mixer::Mixer_max_volume);
     }
-
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/mixer/Channel.cpp
@@ -129,6 +129,11 @@ namespace HyperSonicDrivers::audio::mixer
         {
             m_volR = m_volL = vol / mixer::Channel_max_volume;
         }
+
+        // adjust for master volume
+        const auto m_vol = m_mixer.getMasterVolume();
+        m_volL = ((m_volL * m_vol) / mixer::Mixer_max_volume);
+        m_volR = ((m_volR * m_vol) / mixer::Mixer_max_volume);
     }
 
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
@@ -242,12 +242,12 @@ namespace HyperSonicDrivers::audio::sdl2
         const std::scoped_lock lck(m_mutex);
 
         int16_t* buf = std::bit_cast<int16_t*>(samples);
-        // we store stereo, 16-bit samples (2 for stereo, 2 from 8 to 16 bits)
+        // we store stereo, 16-bit samples (div 2 for stereo and 2 from 8 to 16 bits)
         assert(len % 4 == 0);
-        len >>= 2;
-
-        //  zero the buf
-        memset(buf, 0, 2 * len * sizeof(int16_t));
+        len >>= 1;
+        //  zero the buf (size of 2ch stereo: len*2 of 16 bits)
+        memset(buf, 0, len * sizeof(int16_t));
+        len >>= 1; // size of the stereo 16 bits buffer.
 
         // mix all channels
         size_t res = 0;
@@ -255,6 +255,7 @@ namespace HyperSonicDrivers::audio::sdl2
         {
             const size_t tmp = ch->mix(buf, len);
 
+            // TODO: returning a value can be removed
             if (tmp > res)
                 res = tmp;
         }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
@@ -223,6 +223,12 @@ namespace HyperSonicDrivers::audio::sdl2
         m_channels[id]->setVolumePan(volume, pan);
     }
 
+    void Mixer::setMasterVolume(const uint8_t master_volume) noexcept
+    {
+        m_master_volume = master_volume;
+        updateChannelsVolumePan_();
+    }
+
     void Mixer::updateChannelsVolumePan_() noexcept
     {
         std::scoped_lock lck(m_mutex);

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
@@ -82,7 +82,7 @@ namespace HyperSonicDrivers::audio::sdl2
     std::optional<uint8_t> Mixer::play(
         const mixer::eChannelGroup group,
         const std::shared_ptr<IAudioStream>& stream,
-        const uint8_t vol, const int8_t pan, const bool reverseStereo)
+        const uint8_t vol, const int8_t pan)
     {
         // find a free channel
         int i = 0;
@@ -97,7 +97,7 @@ namespace HyperSonicDrivers::audio::sdl2
             return std::nullopt;
         }
 
-        m_channels[i]->setAudioStream(group, stream, vol, pan, reverseStereo);
+        m_channels[i]->setAudioStream(group, stream, vol, pan, m_reverseStereo);
 
         return std::make_optional(static_cast<uint8_t>(i));
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
@@ -82,8 +82,8 @@ namespace HyperSonicDrivers::audio::sdl2
     std::optional<uint8_t> Mixer::play(
         const mixer::eChannelGroup group,
         const std::shared_ptr<IAudioStream>& stream,
-        const uint8_t vol, const int8_t pan)
-    {
+        const uint8_t vol, const int8_t pan
+    ) {
         // find a free channel
         int i = 0;
         for (; i < max_channels; i++)

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.cpp
@@ -50,7 +50,7 @@ namespace HyperSonicDrivers::audio::sdl2
         };
 
         SDL_AudioSpec obtained;
-        m_device_id = SDL_OpenAudioDevice(SDL_GetAudioDeviceName(10, 0), 0, &desired, &obtained, 0);
+        m_device_id = SDL_OpenAudioDevice(nullptr, 0, &desired, &obtained, 0);
         if (m_device_id == 0)
         {
             logE("can't open audio device");

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
@@ -55,6 +55,8 @@ namespace HyperSonicDrivers::audio::sdl2
 
         void setChannelVolumePan(const uint8_t id, const uint8_t volume, const int8_t pan) noexcept override;
 
+        virtual void setMasterVolume(const uint8_t master_volume) noexcept override;
+
     private:
         void updateChannelsVolumePan_() noexcept;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
@@ -24,8 +24,7 @@ namespace HyperSonicDrivers::audio::sdl2
             const mixer::eChannelGroup group,
             const std::shared_ptr<IAudioStream>& stream,
             const uint8_t vol,
-            const int8_t pan,
-            const bool reverseStereo
+            const int8_t pan
         ) override;
 
         void suspend() noexcept override;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/sdl2/Mixer.hpp
@@ -54,7 +54,7 @@ namespace HyperSonicDrivers::audio::sdl2
 
         void setChannelVolumePan(const uint8_t id, const uint8_t volume, const int8_t pan) noexcept override;
 
-        virtual void setMasterVolume(const uint8_t master_volume) noexcept override;
+        void setMasterVolume(const uint8_t master_volume) noexcept override;
 
     private:
         void updateChannelsVolumePan_() noexcept;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/SoundStream.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/SoundStream.cpp
@@ -4,7 +4,7 @@
 
 namespace HyperSonicDrivers::audio::streams
 {
-    using utils::READ_LE_UINT16;
+    using utils::readLE_uint16;
 
     SoundStream::SoundStream(const std::shared_ptr<Sound>& sound)
         : m_sound(sound)

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -44,7 +44,7 @@ namespace HyperSonicDrivers::drivers
         return false;
     }
 
-    std::optional<uint8_t> PCMDriver::play(const std::shared_ptr<audio::Sound>& sound, const uint8_t volume, const int8_t pan, const bool reverseStereo)
+    std::optional<uint8_t> PCMDriver::play(const std::shared_ptr<audio::Sound>& sound, const uint8_t volume, const int8_t pan)
     {
         // find first free slot
         auto it = std::ranges::find_if_not(m_soundStreams, isSoundStreamPlaying_);

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -57,8 +57,7 @@ namespace HyperSonicDrivers::drivers
             sound->group,
             *it,
             volume,
-            pan,
-            reverseStereo
+            pan
         );
 
         if (!channelId.has_value())

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
@@ -27,8 +27,7 @@ namespace HyperSonicDrivers::drivers
         std::optional<uint8_t> play(
             const std::shared_ptr<audio::Sound>& sound,
             const uint8_t volume = audio::mixer::Channel_max_volume,
-            const int8_t pan = 0,
-            const bool reverseStereo = false
+            const int8_t pan = 0
         );
 
         const uint8_t max_streams;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/Device.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/Device.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <atomic>
+#include <memory>
 #include <HyperSonicDrivers/audio/midi/MIDIEvent.hpp>
 
 
@@ -54,5 +55,12 @@ namespace HyperSonicDrivers::drivers
             std::atomic<bool> _acquired = false;
             std::atomic<drivers::MIDDriver*> _owner = nullptr;
         };
+
+        // TODO: replace variadic template with exact arguments
+        template<class T, typename... Args>
+        std::shared_ptr<T> make_device(Args... args)
+        {
+            return std::make_shared<T>(args...);
+        }
     }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/Device.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/Device.hpp
@@ -20,6 +20,9 @@ namespace HyperSonicDrivers::drivers
             Device() = default;
             virtual ~Device() = default;
 
+            // TODO: integrate MT-32 first as a device
+            //virtual bool init() noexcept = 0;
+
             virtual void sendEvent(const audio::midi::MIDIEvent& e) const noexcept = 0;
             virtual void sendMessage(const uint8_t msg[], const uint8_t size) const noexcept = 0;
             virtual void sendSysEx(const audio::midi::MIDIEvent& e) const noexcept = 0;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.cpp
@@ -4,11 +4,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     Adlib::Adlib(
         const std::shared_ptr<audio::IMixer>& mixer,
-        const audio::mixer::eChannelGroup group,
-        const uint8_t volume,
-        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-        const hardware::opl::OplEmulator emulator)
+        const audio::mixer::eChannelGroup group,
+        const hardware::opl::OplEmulator emulator,
+        const uint8_t volume,
+        const uint8_t pan)
         : Opl(hardware::opl::OplType::OPL2, emulator, mixer, op2Bank, group, volume, pan)
     {
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.cpp
@@ -4,9 +4,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     Adlib::Adlib(
         const std::shared_ptr<audio::IMixer>& mixer,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
         const hardware::opl::OplEmulator emulator)
-        : Opl(hardware::opl::OplType::OPL2, emulator, mixer, op2Bank)
+        : Opl(hardware::opl::OplType::OPL2, emulator, mixer, op2Bank, group, volume, pan)
     {
     }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.hpp
@@ -12,11 +12,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit Adlib(
             const std::shared_ptr<audio::IMixer>& mixer,
-            const audio::mixer::eChannelGroup group,
-            const uint8_t volume,
-            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
+            const audio::mixer::eChannelGroup group,
+            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO,
+            const uint8_t volume = 255,
+            const uint8_t pan = 0);
 
         ~Adlib() override = default;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Adlib.hpp
@@ -12,6 +12,9 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit Adlib(
             const std::shared_ptr<audio::IMixer>& mixer,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
             const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Opl.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Opl.cpp
@@ -10,7 +10,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     using utils::throwLogC;
 
-    Opl::Opl(const std::shared_ptr<hardware::opl::OPL>& opl, const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank)
+    Opl::Opl(
+        const std::shared_ptr<hardware::opl::OPL>& opl,
+        const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan)
         : Device()/*, OplDriver(opl, op2Bank, opl3_mode)*/
     {
         if (opl == nullptr)
@@ -18,20 +23,23 @@ namespace HyperSonicDrivers::drivers::midi::devices
             throwLogC<std::runtime_error>("opl is nullptr");
         }
 
-        _oplDriver = std::make_shared<drivers::midi::opl::OplDriver>(opl, op2Bank);
+        _oplDriver = std::make_shared<drivers::midi::opl::OplDriver>(opl, op2Bank, group, volume, pan);
     }
 
     Opl::Opl(const hardware::opl::OplType type,
         const hardware::opl::OplEmulator emuType,
         const std::shared_ptr<audio::IMixer>& mixer,
-        const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank)
+        const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan)
     {
         auto opl = hardware::opl::OPLFactory::create(emuType, type, mixer);
         if (opl == nullptr || opl->type != type)
         {
             throwLogC<std::runtime_error>(std::format("device Opl not supporting emu_type={}, type={}", emuType, type));
         }
-        _oplDriver = std::make_shared<drivers::midi::opl::OplDriver>(opl, op2Bank);
+        _oplDriver = std::make_shared<drivers::midi::opl::OplDriver>(opl, op2Bank, group, volume, pan);
     }
 
     void Opl::sendEvent(const audio::midi::MIDIEvent& e) const noexcept

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Opl.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/Opl.hpp
@@ -27,15 +27,22 @@ namespace HyperSonicDrivers::drivers::midi::devices
 
         // TODO review the constructors and use a load bank instead..
         /** @deprecated */
-        [[deprecated("use the other constructor that creates the OPL chip internally")]] explicit Opl(
+        [[deprecated("use the other constructor that creates the OPL chip internally (still used on device::scummvm)")]]
+        explicit Opl(
             const std::shared_ptr<hardware::opl::OPL>& opl,
-            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank);
+            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan);
 
         explicit Opl(
             const hardware::opl::OplType type,
             const hardware::opl::OplEmulator emuType,
             const std::shared_ptr<audio::IMixer>& mixer,
-            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank);
+            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan);
         ~Opl() override = default;
 
     private:

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.cpp
@@ -4,9 +4,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     SbPro::SbPro(
         const std::shared_ptr<audio::IMixer>& mixer,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
         const hardware::opl::OplEmulator emulator)
-        : Opl(hardware::opl::OplType::DUAL_OPL2, emulator, mixer, op2Bank)
+        : Opl(hardware::opl::OplType::DUAL_OPL2, emulator, mixer, op2Bank, group, volume, pan)
     {
     }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.cpp
@@ -4,11 +4,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     SbPro::SbPro(
         const std::shared_ptr<audio::IMixer>& mixer,
-        const audio::mixer::eChannelGroup group,
-        const uint8_t volume,
-        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-        const hardware::opl::OplEmulator emulator)
+        const audio::mixer::eChannelGroup group,
+        const hardware::opl::OplEmulator emulator,
+        const uint8_t volume,
+        const uint8_t pan)
         : Opl(hardware::opl::OplType::DUAL_OPL2, emulator, mixer, op2Bank, group, volume, pan)
     {
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.hpp
@@ -12,6 +12,9 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit SbPro(
             const std::shared_ptr<audio::IMixer>& mixer,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
             const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro.hpp
@@ -12,11 +12,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit SbPro(
             const std::shared_ptr<audio::IMixer>& mixer,
-            const audio::mixer::eChannelGroup group,
-            const uint8_t volume,
-            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
+            const audio::mixer::eChannelGroup group,
+            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO,
+            const uint8_t volume = 255,
+            const uint8_t pan = 0);
 
         ~SbPro() override = default;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.cpp
@@ -4,11 +4,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     SbPro2::SbPro2(
         const std::shared_ptr<audio::IMixer>& mixer,
-        const audio::mixer::eChannelGroup group,
-        const uint8_t volume,
-        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-        const hardware::opl::OplEmulator emulator)
+        const audio::mixer::eChannelGroup group,
+        const hardware::opl::OplEmulator emulator,
+        const uint8_t volume,
+        const uint8_t pan)
         : Opl(hardware::opl::OplType::OPL3, emulator, mixer, op2Bank, group, volume, pan)
     {
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.cpp
@@ -4,9 +4,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
 {
     SbPro2::SbPro2(
         const std::shared_ptr<audio::IMixer>& mixer,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan,
         const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
         const hardware::opl::OplEmulator emulator)
-        : Opl(hardware::opl::OplType::OPL3, emulator, mixer, op2Bank)
+        : Opl(hardware::opl::OplType::OPL3, emulator, mixer, op2Bank, group, volume, pan)
     {
     }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.hpp
@@ -12,11 +12,11 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit SbPro2(
             const std::shared_ptr<audio::IMixer>& mixer,
-            const audio::mixer::eChannelGroup group,
-            const uint8_t volume,
-            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
-            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
+            const audio::mixer::eChannelGroup group,
+            const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO,
+            const uint8_t volume = 255,
+            const uint8_t pan = 0);
 
         ~SbPro2() override = default;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/SbPro2.hpp
@@ -12,6 +12,9 @@ namespace HyperSonicDrivers::drivers::midi::devices
     public:
         explicit SbPro2(
             const std::shared_ptr<audio::IMixer>& mixer,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
             const hardware::opl::OplEmulator emulator = hardware::opl::OplEmulator::AUTO);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.cpp
@@ -4,10 +4,13 @@
 
 namespace HyperSonicDrivers::drivers::midi::devices
 {
-    ScummVM::ScummVM(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode) : Device()
+    ScummVM::ScummVM(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan) : Device()
     {
         _adlib = std::make_shared<drivers::midi::scummvm::MidiDriver_ADLIB>(opl, opl3mode);
-        _adlib->open();
+        _adlib->open(group, volume, pan);
     }
 
     ScummVM::~ScummVM()

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.hpp
@@ -21,8 +21,8 @@ namespace HyperSonicDrivers::drivers::midi::devices
         [[deprecated]]
         explicit ScummVM(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode,
             const audio::mixer::eChannelGroup group,
-            const uint8_t volume,
-            const uint8_t pan);
+            const uint8_t volume = 255,
+            const uint8_t pan = 0);
 
         ~ScummVM() override;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/devices/ScummVM.hpp
@@ -19,7 +19,10 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
     public:
         [[deprecated]]
-        explicit ScummVM(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode);
+        explicit ScummVM(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan);
 
         ~ScummVM() override;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
@@ -115,8 +115,6 @@ namespace HyperSonicDrivers::drivers::midi::opl
             else
                 ++it;
         }
-
-        //spdlog::debug("noteOff {} {} ({})", chan, note, _voiceIndexesInUse.size());
     }
 
     void OplDriver::noteOn(const uint8_t chan, const uint8_t note, const uint8_t vol) noexcept
@@ -142,8 +140,6 @@ namespace HyperSonicDrivers::drivers::midi::opl
                 if (freeSlot != -1)
                     allocateVoice(freeSlot, chan, note, vol, instr, true);
             }
-
-            //spdlog::debug("noteOn note={:d} ({:d}) - vol={:d} ({:d}) - pitch={:d} - ch={:d}", voice->_note, voice->_realnote, /*voice->volume*/ -1, /*voice->realvolume*/ -1, voice->pitch, voice->_channel);
         }
         else
         {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
@@ -38,7 +38,7 @@ namespace HyperSonicDrivers::drivers::midi::opl
 
         hardware::opl::TimerCallBack cb = std::bind(&OplDriver::onTimer, this);
         auto p = std::make_shared<hardware::opl::TimerCallBack>(cb);
-        _opl->start(p);
+        _opl->start(p,);
     }
 
     OplDriver::~OplDriver()

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.cpp
@@ -18,9 +18,12 @@ namespace HyperSonicDrivers::drivers::midi::opl
     // TODO: allocateVoice and getFreeSlot should be merged into 1 function
 
     OplDriver::OplDriver(const std::shared_ptr<hardware::opl::OPL>& opl,
-        const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank) :
+        const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan) :
         _opl(opl), _op2Bank(op2Bank), _opl3_mode(opl->type == OplType::OPL3),
-        _oplNumChannels(_opl3_mode ? drivers::opl::OPL3_NUM_CHANNELS : drivers::opl::OPL2_NUM_CHANNELS)
+        _oplNumChannels(_opl3_mode ? drivers::opl::opl3_num_channels : drivers::opl::opl2_num_channels)
     {
         _oplWriter = std::make_unique<drivers::opl::OplWriter>(_opl, _opl3_mode);
 
@@ -38,7 +41,7 @@ namespace HyperSonicDrivers::drivers::midi::opl
 
         hardware::opl::TimerCallBack cb = std::bind(&OplDriver::onTimer, this);
         auto p = std::make_shared<hardware::opl::TimerCallBack>(cb);
-        _opl->start(p,);
+        _opl->start(p, group, volume, pan);
     }
 
     OplDriver::~OplDriver()

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/opl/OplDriver.hpp
@@ -27,8 +27,12 @@ namespace HyperSonicDrivers::drivers::midi::opl
     class OplDriver
     {
     public:
+        [[deprecated("replace opl argument with device")]]
         OplDriver(const std::shared_ptr<hardware::opl::OPL>& opl,
-            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank);
+            const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan);
         ~OplDriver();
 
         void send(const audio::midi::MIDIEvent& e) /*const*/ noexcept;
@@ -43,7 +47,7 @@ namespace HyperSonicDrivers::drivers::midi::opl
         std::array<std::unique_ptr<OplChannel>, audio::midi::MIDI_MAX_CHANNELS>  _channels;
 
         // TODO: this if is OPL2 should have less
-        std::array<std::unique_ptr<OplVoice>, drivers::opl::OPL3_NUM_CHANNELS> _voices;
+        std::array<std::unique_ptr<OplVoice>, drivers::opl::opl3_num_channels> _voices;
         std::unique_ptr<drivers::opl::OplWriter> _oplWriter;
 
         // TODO review to make this index more efficient (and its complementary)

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <cstdint>
 #include <HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_BASE.hpp>
+#include <HyperSonicDrivers/audio/mixer/ChannelGroup.hpp>
 
 namespace HyperSonicDrivers::drivers::midi::scummvm
 {
@@ -105,7 +106,10 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
          * Open the midi driver.
          * @return 0 if successful, otherwise an error code.
          */
-        virtual int open() = 0;
+        virtual int open(
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan) = 0;
 
         /**
          * Check whether the midi driver has already been opened.

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
@@ -138,7 +138,7 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
 
         hardware::opl::TimerCallBack cb = std::bind(&MidiDriver_ADLIB::onTimer, this);
         auto p = std::make_shared<hardware::opl::TimerCallBack>(cb);
-        _opl->start(p);
+        _opl->start(p,);
 
         return 0;
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.cpp
@@ -106,7 +106,10 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
             close();
     }
 
-    int MidiDriver_ADLIB::open()
+    int MidiDriver_ADLIB::open(
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan)
     {
         if (_isOpen)
             return 4; //MERR_ALREADY_OPEN;
@@ -138,7 +141,7 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
 
         hardware::opl::TimerCallBack cb = std::bind(&MidiDriver_ADLIB::onTimer, this);
         auto p = std::make_shared<hardware::opl::TimerCallBack>(cb);
-        _opl->start(p,);
+        _opl->start(p, group, volume, pan);
 
         return 0;
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
@@ -30,7 +30,9 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
         MidiDriver_ADLIB(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3mode);
         ~MidiDriver_ADLIB() override;
 
-        int open() override;
+        int open(const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan) override;
         void close() override;
         void send(uint32_t b) override;
         void send(int8_t channel, uint32_t b) override; // Supports higher than channel 15

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/midi/scummvm/MidiDriver_ADLIB.hpp
@@ -36,7 +36,7 @@ namespace HyperSonicDrivers::drivers::midi::scummvm
         void send(int8_t channel, uint32_t b) override; // Supports higher than channel 15
         uint32_t property(int prop, uint32_t param) override;
         bool isOpen() const override { return _isOpen; }
-        uint32_t getBaseTempo() override { return 1000000 / hardware::opl::DEFAULT_CALLBACK_FREQUENCY; }
+        uint32_t getBaseTempo() override { return 1000000 / hardware::opl::default_opl_callback_freq; }
 
         void setPitchBendRange(uint8_t channel, unsigned int range) override;
         void sysEx_customInstrument(uint8_t channel, uint32_t type, const uint8_t* instr) override;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/opl/OplWriter.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/opl/OplWriter.cpp
@@ -6,7 +6,7 @@ namespace HyperSonicDrivers::drivers::opl
 {
     OplWriter::OplWriter(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3_mode) :
         _opl(opl), _opl3_mode(opl3_mode),
-        _oplNumChannels(opl3_mode ? OPL3_NUM_CHANNELS : OPL2_NUM_CHANNELS)
+        _oplNumChannels(opl3_mode ? opl3_num_channels : opl2_num_channels)
     {
     }
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/opl/OplWriter.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/opl/OplWriter.hpp
@@ -4,11 +4,12 @@
 #include <memory>
 #include <HyperSonicDrivers/hardware/opl/OPL.hpp>
 #include <HyperSonicDrivers/hardware/opl/OPL2instrument.h>
+#include <HyperSonicDrivers/audio/mixer/ChannelGroup.hpp>
 
 namespace HyperSonicDrivers::drivers::opl
 {
-    constexpr uint8_t OPL2_NUM_CHANNELS = 9;
-    constexpr uint8_t OPL3_NUM_CHANNELS = 18;
+    constexpr uint8_t opl2_num_channels = 9;
+    constexpr uint8_t opl3_num_channels = 18;
 
     class OplWriter
     {
@@ -17,6 +18,7 @@ namespace HyperSonicDrivers::drivers::opl
         OplWriter(OplWriter&) = delete;
         OplWriter(OplWriter&&) = delete;
         OplWriter& operator=(const OplWriter&) = delete;
+
         explicit OplWriter(const std::shared_ptr<hardware::opl::OPL>& opl, const bool opl3_mode);
         ~OplWriter();
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.cpp
@@ -72,15 +72,11 @@ namespace HyperSonicDrivers::drivers::westwood
 
     void ADLDriver::initDriver_()
     {
-        //const std::scoped_lock lock(m_mutex);
-
         resetAdLibState_();
     }
 
     void ADLDriver::startSound_(const int track, const int volume)
     {
-        //const std::scoped_lock lock(m_mutex);
-
         uint8_t* trackData = getProgram_(track);
         if (trackData == nullptr) {
             return;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.cpp
@@ -28,7 +28,7 @@ namespace HyperSonicDrivers::drivers::westwood
         const audio::mixer::eChannelGroup group,
         const uint8_t volume,
         const uint8_t pan
-    ) : m_opl(opl), m_rnd(random_seed)
+    ) : m_rnd(random_seed), m_opl(opl)
     {
         if (!m_opl || !m_opl->init())
         {
@@ -75,7 +75,7 @@ namespace HyperSonicDrivers::drivers::westwood
         resetAdLibState_();
     }
 
-    void ADLDriver::startSound_(const int track, const int volume)
+    void ADLDriver::startSound_(const uint8_t track, const uint8_t volume)
     {
         uint8_t* trackData = getProgram_(track);
         if (trackData == nullptr) {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
@@ -30,7 +30,7 @@ namespace HyperSonicDrivers::drivers::westwood
     class ADLDriver
     {
     public:
-        [[deprecated]]
+        [[deprecated("use an opl device instead of opl")]]
         explicit ADLDriver(
             const std::shared_ptr<hardware::opl::OPL>& opl,
             const audio::mixer::eChannelGroup group,
@@ -53,11 +53,11 @@ namespace HyperSonicDrivers::drivers::westwood
         void setOplMusicVolume(const uint8_t volume);
         void setOplSfxVolume(const uint8_t volume);
 
-        void play(const uint8_t track, const uint8_t volume);
+        void play(const uint8_t track, const uint8_t volume = 0xFF);
         bool isPlaying();
     private:
-        void initDriver();
-        void startSound(const int track, const int volume);
+        void initDriver_();
+        void startSound_(const int track, const int volume);
 
         std::shared_ptr<files::westwood::ADLFile> m_adl_file = nullptr;
 
@@ -65,9 +65,9 @@ namespace HyperSonicDrivers::drivers::westwood
         uint32_t m_soundDataSize;
 
         // The sound data has two lookup tables:
-        uint8_t* getProgram(const int progId);
-        const uint8_t* getInstrument(const int instrumentId);
-        uint8_t* getProgram(const int progId, const files::westwood::ADLFile::PROG_TYPE progType);
+        uint8_t* getProgram_(const int progId) const;
+        const uint8_t* getInstrument_(const int instrumentId) const;
+        uint8_t* getProgram_(const int progId, const files::westwood::ADLFile::PROG_TYPE progType) const;
 
         struct Channel
         {
@@ -123,41 +123,41 @@ namespace HyperSonicDrivers::drivers::westwood
             uint8_t volumeModifier;
         };
 
-        void primaryEffectSlide(Channel& channel);
-        void primaryEffectVibrato(Channel& channel);
-        void secondaryEffect1(Channel& channel);
+        void primaryEffectSlide_(Channel& channel);
+        void primaryEffectVibrato_(Channel& channel);
+        void secondaryEffect1_(Channel& channel);
 
-        void resetAdLibState();
-        void writeOPL(uint8_t reg, uint8_t val);
-        void initChannel(Channel& channel);
-        void noteOff(Channel& channel);
-        void initAdlibChannel(uint8_t num);
+        void resetAdLibState_();
+        void writeOPL_(uint8_t reg, uint8_t val);
+        void initChannel_(Channel& channel);
+        void noteOff_(Channel& channel);
+        void initAdlibChannel_(uint8_t num);
 
-        uint16_t getRandomNr();
-        void setupDuration(uint8_t duration, Channel& channel);
+        uint16_t getRandomNr_();
+        void setupDuration_(uint8_t duration, Channel& channel);
 
-        void setupNote(uint8_t rawNote, Channel& channel, bool flag = false);
+        void setupNote_(uint8_t rawNote, Channel& channel, bool flag = false);
         // TODO: dataptr can be replace with Opl2Instrument_t, it might requires to be mapped
         //       as is organized differently internally in the file.
-        void setupInstrument(uint8_t regOffset, const uint8_t* dataptr, Channel& channel);
-        void noteOn(Channel& channel);
+        void setupInstrument_(uint8_t regOffset, const uint8_t* dataptr, Channel& channel);
+        void noteOn_(Channel& channel);
 
-        void adjustVolume(Channel& channel);
+        void adjustVolume_(Channel& channel);
 
-        uint8_t calculateOpLevel1(Channel& channel);
-        uint8_t calculateOpLevel2(Channel& channel);
+        uint8_t calculateOpLevel1_(Channel& channel);
+        uint8_t calculateOpLevel2_(Channel& channel);
 
-        static uint16_t checkValue(int16_t val);
+        static uint16_t checkValue_(int16_t val);
 
         // The driver uses timer/tempo pairs in several places. On every
         // callback, the tempo is added to the timer. This will frequently
         // cause the timer to "wrap around", which is the signal to go ahead
         // and do more stuff.
-        static bool advance(uint8_t& timer, uint8_t tempo);
-        const uint8_t* checkDataOffset(const uint8_t* ptr, long n);
+        static bool advance_(uint8_t& timer, uint8_t tempo);
+        const uint8_t* checkDataOffset_(const uint8_t* ptr, long n);
 
-        void setupPrograms();
-        void executePrograms();
+        void setupPrograms_();
+        void executePrograms_();
 
         struct ParserOpcode
         {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
@@ -31,7 +31,12 @@ namespace HyperSonicDrivers::drivers::westwood
     {
     public:
         [[deprecated]]
-        explicit ADLDriver(const std::shared_ptr<hardware::opl::OPL>& opl, const std::shared_ptr<files::westwood::ADLFile>& adl_file);
+        explicit ADLDriver(
+            const std::shared_ptr<hardware::opl::OPL>& opl,
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume = 255,
+            const uint8_t pan = 0
+        );
         // NOTE: midi:devices:Adlib, it should receive devices::Adlib instead of OPL, but those are working only with MIDDriver
         //explicit ADLDriver(const midi::devices::Adlib& opl, const std::shared_ptr<files::westwood::ADLFile>& adl_file);
         virtual ~ADLDriver() = default;
@@ -45,8 +50,8 @@ namespace HyperSonicDrivers::drivers::westwood
         void callback();
         void setSyncJumpMask(const uint16_t mask);
 
-        void setMusicVolume(const uint8_t volume);
-        void setSfxVolume(const uint8_t volume);
+        void setOplMusicVolume(const uint8_t volume);
+        void setOplSfxVolume(const uint8_t volume);
 
         void play(const uint8_t track, const uint8_t volume);
         bool isPlaying();
@@ -294,8 +299,8 @@ namespace HyperSonicDrivers::drivers::westwood
 
         mutable std::mutex m_mutex;
 
-        uint8_t m_musicVolume = 0;
-        uint8_t m_sfxVolume = 0;
+        uint8_t m_oplMusicVolume = 0;
+        uint8_t m_oplSfxVolume = 0;
 
         // Version 1,2,3 possible values, version 3&4 merged into version 3
         uint8_t m_version = 0;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
@@ -34,7 +34,7 @@ namespace HyperSonicDrivers::drivers::westwood
         explicit ADLDriver(const std::shared_ptr<hardware::opl::OPL>& opl, const std::shared_ptr<files::westwood::ADLFile>& adl_file);
         // NOTE: midi:devices:Adlib, it should receive devices::Adlib instead of OPL, but those are working only with MIDDriver
         //explicit ADLDriver(const midi::devices::Adlib& opl, const std::shared_ptr<files::westwood::ADLFile>& adl_file);
-        virtual ~ADLDriver();
+        virtual ~ADLDriver() = default;
         void setADLFile(const std::shared_ptr<files::westwood::ADLFile>& adl_file) noexcept;
 
         bool isChannelPlaying(const int channel);
@@ -64,7 +64,8 @@ namespace HyperSonicDrivers::drivers::westwood
         const uint8_t* getInstrument(const int instrumentId);
         uint8_t* getProgram(const int progId, const files::westwood::ADLFile::PROG_TYPE progType);
 
-        struct Channel {
+        struct Channel
+        {
             bool lock;	// New to ScummVM
             uint8_t opExtraLevel2;
             const uint8_t* dataptr;
@@ -161,8 +162,8 @@ namespace HyperSonicDrivers::drivers::westwood
             int values;
         };
 
-        static const std::array<ParserOpcode, 75> _parserOpcodeTable;
-        static const int _parserOpcodeTableSize;
+        static const std::array<ParserOpcode, 75> m_parserOpcodeTable;
+        static const int m_parserOpcodeTableSize;
 
         int update_setRepeat(Channel& channel, const uint8_t* values);
         int update_checkRepeat(Channel& channel, const uint8_t* values);
@@ -221,31 +222,31 @@ namespace HyperSonicDrivers::drivers::westwood
         int updateCallback56(Channel& channel, const uint8_t* values);
 
     private:
-        int _curChannel;
-        uint8_t _soundTrigger;
+        int m_curChannel = 0;
+        uint8_t m_soundTrigger = 0;
 
-        uint16_t _rnd;
+        uint16_t m_rnd;
 
-        uint8_t _beatDivider;
-        uint8_t _beatDivCnt;
-        uint8_t _callbackTimer;
-        uint8_t _beatCounter;
-        uint8_t _beatWaiting;
-        uint8_t _opLevelBD;
-        uint8_t _opLevelHH;
-        uint8_t _opLevelSD;
-        uint8_t _opLevelTT;
-        uint8_t _opLevelCY;
-        uint8_t _opExtraLevel1HH;
-        uint8_t _opExtraLevel2HH;
-        uint8_t _opExtraLevel1CY;
-        uint8_t _opExtraLevel2CY;
-        uint8_t _opExtraLevel2TT;
-        uint8_t _opExtraLevel1TT;
-        uint8_t _opExtraLevel1SD;
-        uint8_t _opExtraLevel2SD;
-        uint8_t _opExtraLevel1BD;
-        uint8_t _opExtraLevel2BD;
+        uint8_t m_beatDivider = 0;
+        uint8_t m_beatDivCnt = 0;
+        uint8_t m_callbackTimer = 0xFF;
+        uint8_t m_beatCounter = 0;
+        uint8_t m_beatWaiting = 0;
+        uint8_t m_opLevelBD = 0;
+        uint8_t m_opLevelHH = 0;
+        uint8_t m_opLevelSD = 0;
+        uint8_t m_opLevelTT = 0;
+        uint8_t m_opLevelCY = 0;
+        uint8_t m_opExtraLevel1HH = 0;
+        uint8_t m_opExtraLevel2HH = 0;
+        uint8_t m_opExtraLevel1CY = 0;
+        uint8_t m_opExtraLevel2CY = 0;
+        uint8_t m_opExtraLevel2TT = 0;
+        uint8_t m_opExtraLevel1TT = 0;
+        uint8_t m_opExtraLevel1SD = 0;
+        uint8_t m_opExtraLevel2SD = 0;
+        uint8_t m_opExtraLevel1BD = 0;
+        uint8_t m_opExtraLevel2BD = 0;
 
         std::shared_ptr<hardware::opl::OPL> m_opl;
 
@@ -258,42 +259,43 @@ namespace HyperSonicDrivers::drivers::westwood
             uint8_t volume;
         };
 
-        std::array<QueueEntry, 16> _programQueue;
-        int _programStartTimeout;
-        int _programQueueStart, _programQueueEnd;
-        bool _retrySounds;
+        std::array<QueueEntry, 16> m_programQueue;
+        int m_programStartTimeout = 0;
+        int m_programQueueStart = 0;
+        int m_programQueueEnd = 0;
+        bool m_retrySounds = false;
 
         void adjustSfxData(uint8_t* data, int volume);
-        uint8_t* _sfxPointer;
-        int _sfxPriority;
-        int _sfxVelocity;
+        uint8_t* m_sfxPointer = 0;
+        int m_sfxPriority;
+        int m_sfxVelocity;
 
         std::array<Channel, 10>  m_channels;
 
-        uint8_t _vibratoAndAMDepthBits;
-        uint8_t _rhythmSectionBits;
+        uint8_t m_vibratoAndAMDepthBits = 0;
+        uint8_t m_rhythmSectionBits = 0;
 
-        uint8_t _curRegOffset;
-        uint8_t _tempo;
+        uint8_t m_curRegOffset = 0;
+        uint8_t m_tempo = 0;
 
-        const uint8_t* _tablePtr1;
-        const uint8_t* _tablePtr2;
+        const uint8_t* m_tablePtr1 = nullptr;
+        const uint8_t* m_tablePtr2 = nullptr;
 
-        static const uint8_t _regOffset[];
-        static const uint16_t _freqTable[];
+        static const std::array<uint8_t, 9> m_regOffset;
+        static const std::array<uint16_t, 12> m_freqTable;
         static const std::array<const uint8_t*, 6> _unkTable2;
-        static const int _unkTable2Size;
-        static const uint8_t _unkTable2_1[];
-        static const uint8_t _unkTable2_2[];
-        static const uint8_t _unkTable2_3[];
-        static const uint8_t _pitchBendTables[][32];
+        static const int m_unkTable2Size;
+        static const uint8_t m_unkTable2_1[];
+        static const uint8_t m_unkTable2_2[];
+        static const uint8_t m_unkTable2_3[];
+        static const uint8_t m_pitchBendTables[][32];
 
-        uint16_t _syncJumpMask;
+        uint16_t m_syncJumpMask = 0;
 
         mutable std::mutex m_mutex;
 
-        uint8_t m_musicVolume;
-        uint8_t m_sfxVolume;
+        uint8_t m_musicVolume = 0;
+        uint8_t m_sfxVolume = 0;
 
         // Version 1,2,3 possible values, version 3&4 merged into version 3
         uint8_t m_version = 0;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/westwood/ADLDriver.hpp
@@ -57,7 +57,7 @@ namespace HyperSonicDrivers::drivers::westwood
         bool isPlaying();
     private:
         void initDriver_();
-        void startSound_(const int track, const int volume);
+        void startSound_(const uint8_t track, const uint8_t volume);
 
         std::shared_ptr<files::westwood::ADLFile> m_adl_file = nullptr;
 
@@ -271,7 +271,7 @@ namespace HyperSonicDrivers::drivers::westwood
         bool m_retrySounds = false;
 
         void adjustSfxData(uint8_t* data, int volume);
-        uint8_t* m_sfxPointer = 0;
+        uint8_t* m_sfxPointer = nullptr;
         int m_sfxPriority;
         int m_sfxVelocity;
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/files/dmx/MUSFile.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/files/dmx/MUSFile.cpp
@@ -26,7 +26,7 @@ namespace HyperSonicDrivers::files::dmx
     using audio::midi::MIDI_MAX_CHANNELS;
     using audio::midi::MIDI_PERCUSSION_CHANNEL;
 
-    using utils::READ_LE_UINT16;
+    using utils::readLE_uint16;
 
     const int MUSFile::MUS_PLAYBACK_SPEED_DEFAULT = 140;
     const int MUSFile::MUS_PLAYBACK_SPEED_ALTERNATE = 70;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.cpp
@@ -23,8 +23,8 @@ namespace HyperSonicDrivers::hardware::opl
             m_nextTick -= step << FIXP_SHIFT;
             if (!(m_nextTick >> FIXP_SHIFT))
             {
-                if (m_opl->_callback.get() != nullptr)
-                    (*m_opl->_callback)();
+                if (m_opl->m_callback.get() != nullptr)
+                    (*m_opl->m_callback)();
 
                 m_nextTick += m_samplesPerTick;
             }
@@ -50,7 +50,7 @@ namespace HyperSonicDrivers::hardware::opl
         stop();
     }
 
-    uint32_t EmulatedOPL::setCallbackFrequency(int timerFrequency)
+    uint32_t EmulatedOPL::setCallbackFrequency(const int timerFrequency)
     {
         const uint32_t baseFreq = timerFrequency;
         assert(baseFreq != 0);
@@ -68,8 +68,12 @@ namespace HyperSonicDrivers::hardware::opl
         return m_mixer;
     }
 
-    void EmulatedOPL::startCallbacks(int timerFrequency)
-    {
+    void EmulatedOPL::startCallbacks(
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan,
+        const int timerFrequency
+    ) {
         m_stream = std::make_shared<Stream>(
             this,
             isStereo(),
@@ -78,10 +82,10 @@ namespace HyperSonicDrivers::hardware::opl
         );
 
         m_channel_id = m_mixer->play(
-            audio::mixer::eChannelGroup::Plain,
+            group,
             m_stream,
-            audio::mixer::Channel_max_volume,
-            0
+            volume,
+            pan
         );
 
         if (!m_channel_id.has_value()) {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.cpp
@@ -81,9 +81,7 @@ namespace HyperSonicDrivers::hardware::opl
             audio::mixer::eChannelGroup::Plain,
             m_stream,
             audio::mixer::Channel_max_volume,
-            0,
-            // TODO: reverseStereo flag instead of false
-            false
+            0
         );
 
         if (!m_channel_id.has_value()) {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/EmulatedOPL.hpp
@@ -44,14 +44,18 @@ namespace HyperSonicDrivers::hardware::opl
         ~EmulatedOPL() override;
 
         // OPL API
-        uint32_t setCallbackFrequency(int timerFrequency) override;
+        uint32_t setCallbackFrequency(const int timerFrequency) override;
 
         std::shared_ptr<audio::IMixer> getMixer() const noexcept;
 
     protected:
         std::shared_ptr<audio::IMixer> m_mixer;
         // OPL API
-        void startCallbacks(int timerFrequency) override;
+        void startCallbacks(
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
+            const int timerFrequency) override;
         void stopCallbacks() override;
 
         /**

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.cpp
@@ -6,22 +6,8 @@ namespace HyperSonicDrivers::hardware::opl
 {
     using utils::logE;
 
-    // TODO: review to allow to have multiple OPL chips instead.
-    static bool _hasInstance;
-
     OPL::OPL(const OplType type) : type(type)
     {
-        if (_hasInstance)
-        {
-            logE("There are multiple OPL output instances running");
-        }
-
-        _hasInstance = true;
-    }
-
-    OPL::~OPL()
-    {
-        _hasInstance = false;
     }
 
     void OPL::start(

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.cpp
@@ -24,15 +24,20 @@ namespace HyperSonicDrivers::hardware::opl
         _hasInstance = false;
     }
 
-    void OPL::start(const std::shared_ptr<TimerCallBack>& callback, int timerFrequency)
+    void OPL::start(
+        const std::shared_ptr<TimerCallBack>& callback,
+        const audio::mixer::eChannelGroup group,
+        const uint8_t volume,
+        const uint8_t pan,
+        const int timerFrequency)
     {
-        _callback = callback;
-        startCallbacks(timerFrequency);
+        m_callback = callback;
+        startCallbacks(group, volume, pan, timerFrequency);
     }
 
     void OPL::stop()
     {
         stopCallbacks();
-        _callback.reset();
+        m_callback.reset();
     }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
@@ -23,7 +23,7 @@ namespace HyperSonicDrivers::hardware::opl
         OPL& operator=(const  OPL&) = delete;
 
         explicit OPL(const OplType type);
-        virtual ~OPL();
+        virtual ~OPL() = default;
 
         const OplType type;
 
@@ -80,7 +80,7 @@ namespace HyperSonicDrivers::hardware::opl
             const audio::mixer::eChannelGroup group = audio::mixer::eChannelGroup::Plain,
             const uint8_t volume = 255,
             const uint8_t pan = 0,
-            int timerFrequency = default_opl_callback_freq);
+            const int timerFrequency = default_opl_callback_freq);
 
         /**
          * Stop the OPL
@@ -114,8 +114,5 @@ namespace HyperSonicDrivers::hardware::opl
          * The functor for callbacks.
          */
         std::shared_ptr<TimerCallBack> m_callback;
-    private:
-        // moved into cpp file
-        //static bool _hasInstance;
     };
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
@@ -78,7 +78,7 @@ namespace HyperSonicDrivers::hardware::opl
         void start(
             const std::shared_ptr<TimerCallBack>& callback,
             const audio::mixer::eChannelGroup group = audio::mixer::eChannelGroup::Plain,
-            const uint8_t volume = 0,
+            const uint8_t volume = 255,
             const uint8_t pan = 0,
             int timerFrequency = default_opl_callback_freq);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
@@ -4,10 +4,11 @@
 #include <memory>
 #include <functional>
 #include <HyperSonicDrivers/hardware/opl/OplType.hpp>
+#include <HyperSonicDrivers/audio/mixer/ChannelGroup.hpp>
 
 namespace HyperSonicDrivers::hardware::opl
 {
-    constexpr int DEFAULT_CALLBACK_FREQUENCY = 250;
+    constexpr int default_opl_callback_freq = 250;
 
     typedef std::function<void()> TimerCallBack;
 
@@ -26,15 +27,9 @@ namespace HyperSonicDrivers::hardware::opl
 
         const OplType type;
 
-        inline bool isInit() const noexcept
-        {
-            return _init;
-        }
+        inline bool isInit() const noexcept { return m_init; }
 
-        inline bool isStereo() const noexcept
-        {
-            return type != OplType::OPL2;
-        }
+        inline bool isStereo() const noexcept { return type != OplType::OPL2; }
 
         /**
          * Initializes the OPL emulator.
@@ -79,7 +74,13 @@ namespace HyperSonicDrivers::hardware::opl
         /**
          * Start the OPL with callbacks.
          */
-        void start(const std::shared_ptr<TimerCallBack>& callback, int timerFrequency = DEFAULT_CALLBACK_FREQUENCY);
+        //void start(const std::shared_ptr<TimerCallBack>& callback, int timerFrequency = default_opl_callback_freq);
+        void start(
+            const std::shared_ptr<TimerCallBack>& callback,
+            const audio::mixer::eChannelGroup group = audio::mixer::eChannelGroup::Plain,
+            const uint8_t volume = 0,
+            const uint8_t pan = 0,
+            int timerFrequency = default_opl_callback_freq);
 
         /**
          * Stop the OPL
@@ -90,14 +91,19 @@ namespace HyperSonicDrivers::hardware::opl
          * Change the callback frequency. This must only be called from a
          * timer proc.
          */
-        virtual uint32_t setCallbackFrequency(int timerFrequency) = 0;
+        virtual uint32_t setCallbackFrequency(const int timerFrequency) = 0;
 
     protected:
-        bool _init = false;
+        bool m_init = false;
         /**
          * Start the callbacks.
          */
-        virtual void startCallbacks(int timerFrequency) = 0;
+        virtual void startCallbacks(
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
+            const int timerFrequency
+        ) = 0;
 
         /**
          * Stop the callbacks.
@@ -107,7 +113,7 @@ namespace HyperSonicDrivers::hardware::opl
         /**
          * The functor for callbacks.
          */
-        std::shared_ptr<TimerCallBack> _callback;
+        std::shared_ptr<TimerCallBack> m_callback;
     private:
         // moved into cpp file
         //static bool _hasInstance;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPL.hpp
@@ -74,7 +74,6 @@ namespace HyperSonicDrivers::hardware::opl
         /**
          * Start the OPL with callbacks.
          */
-        //void start(const std::shared_ptr<TimerCallBack>& callback, int timerFrequency = default_opl_callback_freq);
         void start(
             const std::shared_ptr<TimerCallBack>& callback,
             const audio::mixer::eChannelGroup group = audio::mixer::eChannelGroup::Plain,

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPLFactory.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPLFactory.hpp
@@ -23,7 +23,8 @@ namespace HyperSonicDrivers::hardware::opl
         OPLFactory(OPLFactory&) = delete;
         OPLFactory(OPLFactory&&) = delete;
         OPLFactory& operator=(OPLFactory&) = delete;
-
+        OPLFactory() = delete;
+        ~OPLFactory() = delete;
         /**
          * Creates the specific driver with a specific type setup.
          */

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPLFactory.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/OPLFactory.hpp
@@ -20,6 +20,10 @@ namespace HyperSonicDrivers::hardware::opl
     class OPLFactory
     {
     public:
+        OPLFactory(OPLFactory&) = delete;
+        OPLFactory(OPLFactory&&) = delete;
+        OPLFactory& operator=(OPLFactory&) = delete;
+
         /**
          * Creates the specific driver with a specific type setup.
          */

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/mame/MameOPL3.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/mame/MameOPL3.cpp
@@ -29,7 +29,7 @@ namespace HyperSonicDrivers::hardware::opl::mame
     }
     bool MameOPL3::init()
     {
-        if (_init)
+        if (m_init)
         {
             return true;
         }
@@ -41,9 +41,9 @@ namespace HyperSonicDrivers::hardware::opl::mame
 
         _chip = ymf262_init(0, OPL3_INTERNAL_FREQ, m_mixer->getOutputRate());
         //_init = _opl != nullptr;
-        _init = _chip != nullptr;
+        m_init = _chip != nullptr;
 
-        return _init;
+        return m_init;
     }
     void MameOPL3::reset()
     {

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/dosbox/DosBoxOPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/dosbox/DosBoxOPL.cpp
@@ -26,7 +26,7 @@ namespace HyperSonicDrivers::hardware::opl::scummvm::dosbox
 
     bool DosBoxOPL::init()
     {
-        _init = false;
+        m_init = false;
         free();
 
         memset(&_reg, 0, sizeof(_reg));
@@ -44,7 +44,7 @@ namespace HyperSonicDrivers::hardware::opl::scummvm::dosbox
             _emulator->WriteReg(0x105, 1);
         }
 
-        _init = true;
+        m_init = true;
         return true;
     }
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/mame/MameOPL2.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/mame/MameOPL2.cpp
@@ -23,14 +23,14 @@ namespace HyperSonicDrivers::hardware::opl::scummvm::mame
 
     bool MameOPL2::init()
     {
-        if (_init)
+        if (m_init)
             return true;
 
         _opl = makeAdLibOPL(m_mixer->getOutputRate());
         memset(&_reg, 0, sizeof(_reg));
-        _init = (_opl != nullptr);
+        m_init = (_opl != nullptr);
 
-        return _init;
+        return m_init;
     }
 
     void MameOPL2::reset()

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/nuked/NukedOPL3.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/scummvm/nuked/NukedOPL3.cpp
@@ -13,7 +13,7 @@ namespace HyperSonicDrivers::hardware::opl::scummvm::nuked
 
     bool NukedOPL::init()
     {
-        if (_init)
+        if (m_init)
             return true;
 
         memset(&_reg, 0, sizeof(_reg));
@@ -24,8 +24,8 @@ namespace HyperSonicDrivers::hardware::opl::scummvm::nuked
             OPL3_WriteReg(chip.get(), 0x105, 0x01);
         }
 
-        _init = true;
-        return _init;
+        m_init = true;
+        return m_init;
     }
 
     void NukedOPL::reset()

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/woody/WoodyOPL.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/hardware/opl/woody/WoodyOPL.cpp
@@ -15,7 +15,7 @@ namespace HyperSonicDrivers::hardware
 
             bool WoodyOPL::init()
             {
-                if (_init)
+                if (m_init)
                     return true;
 
                 stop();
@@ -24,9 +24,9 @@ namespace HyperSonicDrivers::hardware
                 else
                     _opl = std::make_unique<WoodyEmuOPL>(m_mixer->getOutputRate());
 
-                _init = _opl != nullptr;
+                m_init = _opl != nullptr;
 
-                if (!_init)
+                if (!m_init)
                     return false;
 
                 _opl->init();

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/endianness.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/endianness.cpp
@@ -88,14 +88,14 @@ namespace HyperSonicDrivers::utils
             return num;
     }
 
-    uint16_t READ_LE_UINT16(const void* ptr) noexcept
+    uint16_t readLE_uint16(const void* ptr) noexcept
     {
         const uint8_t* b = reinterpret_cast<const uint8_t*>(ptr);
 
         return (b[1] << 8) + b[0];
     }
 
-    uint16_t READ_BE_UINT16(const void* ptr) noexcept
+    uint16_t readBE_uint16(const void* ptr) noexcept
     {
         const uint8_t* b = reinterpret_cast<const uint8_t*>(ptr);
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/endianness.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/endianness.hpp
@@ -11,6 +11,6 @@ namespace HyperSonicDrivers::utils
     int16_t swapLE16(const int16_t num) noexcept;
     int16_t swapBE16(const int16_t num) noexcept;
 
-    uint16_t READ_LE_UINT16(const void* ptr) noexcept;
-    uint16_t READ_BE_UINT16(const void* ptr) noexcept;
+    uint16_t readLE_uint16(const void* ptr) noexcept;
+    uint16_t readBE_uint16(const void* ptr) noexcept;
 }

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/audio/stubs/StubMixer.hpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/audio/stubs/StubMixer.hpp
@@ -51,5 +51,7 @@ namespace HyperSonicDrivers::audio::stubs
         void setChannelPan(const uint8_t id, const int8_t pan) noexcept override {};
 
         void setChannelVolumePan(const uint8_t id, const uint8_t volume, const int8_t pan) noexcept override {};
+
+        void setMasterVolume(const uint8_t master_volume) noexcept override {};
     };
 }

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/audio/stubs/StubMixer.hpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/audio/stubs/StubMixer.hpp
@@ -21,8 +21,7 @@ namespace HyperSonicDrivers::audio::stubs
             const mixer::eChannelGroup group,
             const std::shared_ptr<IAudioStream>& stream,
             const uint8_t vol,
-            const int8_t pan,
-            const bool reverseStereo
+            const int8_t pan
         ) override {
             return std::make_optional(0);
         };

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/EmulatorTestCase.hpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/EmulatorTestCase.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <HyperSonicDrivers/hardware/opl/OplEmulator.hpp>
+#include <HyperSonicDrivers/files/dmx/OP2File.hpp>
+#include <HyperSonicDrivers/audio/stubs/StubMixer.hpp>
+#include <HyperSonicDrivers/audio/mixer/ChannelGroup.hpp>
+#include <HyperSonicDrivers/hardware/opl/OplType.hpp>
+#include <HyperSonicDrivers/hardware/opl/OPLFactory.hpp>
+#include <stdexcept>
+
+namespace HyperSonicDrivers::drivers::midi::devices
+{
+    using audio::stubs::StubMixer;
+    using hardware::opl::OplType;
+    using hardware::opl::OplEmulator;
+    using hardware::opl::OPLFactory;
+    using files::dmx::OP2File;
+    using audio::mixer::eChannelGroup;
+
+    static const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
+
+    template<class T>
+    class EmulatorTestCase : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
+    {
+    public:
+        const hardware::opl::OplEmulator oplEmu = std::get<0>(GetParam());
+        const bool shouldThrow = std::get<1>(GetParam());
+        const files::dmx::OP2File op2File = OP2File(GENMIDI_OP2);
+        const std::shared_ptr<audio::stubs::StubMixer> mixer = std::make_shared<audio::stubs::StubMixer>();
+
+        void test_case()
+        {
+            using audio::mixer::eChannelGroup;
+
+            if (this->shouldThrow)
+            {
+                EXPECT_THROW(
+                    T(this->mixer, this->op2File.getBank(), eChannelGroup::Plain, this->oplEmu),
+                    std::runtime_error
+                );
+            }
+            else {
+                EXPECT_NO_THROW(T(this->mixer, this->op2File.getBank(), eChannelGroup::Plain, this->oplEmu));
+            }
+        }
+    };
+}

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/OplDeviceMock.hpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/OplDeviceMock.hpp
@@ -5,6 +5,7 @@
 #include <HyperSonicDrivers/drivers/midi/devices/Opl.hpp>
 #include <HyperSonicDrivers/hardware/opl/OplType.hpp>
 #include <HyperSonicDrivers/hardware/opl/OplEmulator.hpp>
+#include <HyperSonicDrivers/audio/mixer/ChannelGroup.hpp>
 
 namespace HyperSonicDrivers::drivers::midi::devices
 {
@@ -14,12 +15,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
         explicit OplDeviceMock(
             const std::shared_ptr<hardware::opl::OPL>& opl,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank)
-            : Opl(opl, op2Bank) {}
+            : Opl(opl, op2Bank, audio::mixer::eChannelGroup::Plain, 255, 0) {}
         explicit OplDeviceMock(const hardware::opl::OplType type,
             const hardware::opl::OplEmulator emuType,
             const std::shared_ptr<audio::IMixer>& mixer,
             const std::shared_ptr<audio::opl::banks::OP2Bank>& op2Bank)
-            : Opl(type, emuType, mixer, op2Bank) {}
+            : Opl(type, emuType, mixer, op2Bank, audio::mixer::eChannelGroup::Plain, 255, 0) {}
         ~OplDeviceMock() override = default;
     };
 }

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestAdlib.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestAdlib.cpp
@@ -15,6 +15,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     using hardware::opl::OplEmulator;
     using hardware::opl::OPLFactory;
     using files::dmx::OP2File;
+    using audio::mixer::eChannelGroup;
 
     const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
 
@@ -22,7 +23,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto a = std::make_shared<Adlib>(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(auto a = std::make_shared<Adlib>(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 
     class AdliblEmulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
@@ -38,12 +39,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         if (this->shouldThrow) {
             EXPECT_THROW(
-                auto a = std::make_shared<devices::Adlib>(this->mixer, this->op2File.getBank(), this->oplEmu),
+                auto a = std::make_shared<devices::Adlib>(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
                 std::runtime_error
             );
         }
         else {
-            EXPECT_NO_THROW(auto a = std::make_shared<devices::Adlib>(this->mixer, this->op2File.getBank(), this->oplEmu));
+            EXPECT_NO_THROW(auto a = std::make_shared<devices::Adlib>(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
         }
     }
 
@@ -63,7 +64,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(Adlib(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(Adlib(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestAdlib.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestAdlib.cpp
@@ -7,45 +7,21 @@
 #include <HyperSonicDrivers/hardware/opl/OplType.hpp>
 #include <HyperSonicDrivers/files/dmx/OP2File.hpp>
 #include <HyperSonicDrivers/hardware/opl/OPLFactory.hpp>
+#include <HyperSonicDrivers/drivers/midi/devices/EmulatorTestCase.hpp>
 
 namespace HyperSonicDrivers::drivers::midi::devices
 {
-    using audio::stubs::StubMixer;
-    using hardware::opl::OplType;
-    using hardware::opl::OplEmulator;
-    using hardware::opl::OPLFactory;
-    using files::dmx::OP2File;
-    using audio::mixer::eChannelGroup;
-
-    const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
-
     TEST(Adlib, cstor_)
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto a = std::make_shared<Adlib>(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(auto a = std::make_shared<Adlib>(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 
-    class AdliblEmulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
-    {
-    public:
-        const OplEmulator oplEmu = std::get<0>(GetParam());
-        const bool shouldThrow   = std::get<1>(GetParam());
-        const OP2File op2File    = OP2File(GENMIDI_OP2);
-        const std::shared_ptr<StubMixer> mixer = std::make_shared<StubMixer>();
-
-    };
+    class AdliblEmulator_ : public EmulatorTestCase<Adlib> {};
     TEST_P(AdliblEmulator_, cstr_TYPE)
     {
-        if (this->shouldThrow) {
-            EXPECT_THROW(
-                auto a = std::make_shared<devices::Adlib>(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
-                std::runtime_error
-            );
-        }
-        else {
-            EXPECT_NO_THROW(auto a = std::make_shared<devices::Adlib>(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
-        }
+        test_case();
     }
 
     INSTANTIATE_TEST_SUITE_P(
@@ -64,7 +40,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(Adlib(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(Adlib(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestOpl.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestOpl.cpp
@@ -43,7 +43,6 @@ namespace HyperSonicDrivers::drivers::midi::devices
         const bool shouldThrow = std::get<2>(GetParam());
         const OP2File op2File = OP2File(GENMIDI_OP2);
         const std::shared_ptr<StubMixer> mixer = std::make_shared<StubMixer>();
-
     };
     TEST_P(OplEmulator_, cstr_type_emu)
     {

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestOpl.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestOpl.cpp
@@ -21,6 +21,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     using hardware::opl::OPL;
     using files::dmx::OP2File;
     using files::dmx::OP2File;
+    using audio::mixer::eChannelGroup;
 
     const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro.cpp
@@ -15,6 +15,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     using hardware::opl::OplEmulator;
     using hardware::opl::OPLFactory;
     using files::dmx::OP2File;
+    using audio::mixer::eChannelGroup;
 
     const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
 
@@ -22,7 +23,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto s = SbPro(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(auto s = SbPro(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 
     class SbProEmulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
@@ -38,12 +39,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         if (this->shouldThrow) {
             EXPECT_THROW(
-                devices::SbPro(this->mixer, this->op2File.getBank(), this->oplEmu),
+                devices::SbPro(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
                 std::runtime_error
             );
         }
         else {
-            EXPECT_NO_THROW(devices::SbPro(this->mixer, this->op2File.getBank(), this->oplEmu));
+            EXPECT_NO_THROW(devices::SbPro(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
         }
     }
     INSTANTIATE_TEST_SUITE_P(
@@ -62,7 +63,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(SbPro(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(SbPro(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro.cpp
@@ -1,51 +1,25 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <HyperSonicDrivers/drivers/midi/devices/SbPro.hpp>
-#include <HyperSonicDrivers/drivers/MIDDriverMock.hpp>
-#include <HyperSonicDrivers/audio/stubs/StubMixer.hpp>
-#include <HyperSonicDrivers/hardware/opl/OplEmulator.hpp>
 #include <HyperSonicDrivers/hardware/opl/OplType.hpp>
-#include <HyperSonicDrivers/files/dmx/OP2File.hpp>
 #include <HyperSonicDrivers/hardware/opl/OPLFactory.hpp>
+#include <HyperSonicDrivers/drivers/midi/devices/EmulatorTestCase.hpp>
+
 
 namespace HyperSonicDrivers::drivers::midi::devices
 {
-    using audio::stubs::StubMixer;
-    using hardware::opl::OplType;
-    using hardware::opl::OplEmulator;
-    using hardware::opl::OPLFactory;
-    using files::dmx::OP2File;
-    using audio::mixer::eChannelGroup;
-
-    const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
 
     TEST(SbPro, cstor_)
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto s = SbPro(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(auto s = SbPro(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 
-    class SbProEmulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
-    {
-    public:
-        const OplEmulator oplEmu = std::get<0>(GetParam());
-        const bool shouldThrow = std::get<1>(GetParam());
-        const OP2File op2File = OP2File(GENMIDI_OP2);
-        const std::shared_ptr<StubMixer> mixer = std::make_shared<StubMixer>();
-
-    };
+    class SbProEmulator_ : public EmulatorTestCase<SbPro> {};
     TEST_P(SbProEmulator_, cstr_TYPE)
     {
-        if (this->shouldThrow) {
-            EXPECT_THROW(
-                devices::SbPro(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
-                std::runtime_error
-            );
-        }
-        else {
-            EXPECT_NO_THROW(devices::SbPro(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
-        }
+        test_case();
     }
     INSTANTIATE_TEST_SUITE_P(
         SbPro,
@@ -63,7 +37,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(SbPro(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(SbPro(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro2.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro2.cpp
@@ -15,6 +15,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     using hardware::opl::OplEmulator;
     using hardware::opl::OPLFactory;
     using files::dmx::OP2File;
+    using audio::mixer::eChannelGroup;
 
     const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
 
@@ -22,7 +23,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto s = SbPro2(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(auto s = SbPro2(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 
     class SbPro2Emulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
@@ -38,12 +39,12 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         if (this->shouldThrow) {
             EXPECT_THROW(
-                devices::SbPro2(this->mixer, this->op2File.getBank(), this->oplEmu),
+                devices::SbPro2(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
                 std::runtime_error
             );
         }
         else {
-            EXPECT_NO_THROW(devices::SbPro2(this->mixer, this->op2File.getBank(), this->oplEmu));
+            EXPECT_NO_THROW(devices::SbPro2(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
         }
     }
     INSTANTIATE_TEST_SUITE_P(
@@ -62,7 +63,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(SbPro2(mixer, op2File.getBank()));
+        EXPECT_NO_THROW(SbPro2(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro2.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/midi/devices/TestSbPro2.cpp
@@ -1,52 +1,26 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <HyperSonicDrivers/drivers/midi/devices/EmulatorTestCase.hpp>
 #include <HyperSonicDrivers/drivers/midi/devices/SbPro2.hpp>
-#include <HyperSonicDrivers/drivers/MIDDriverMock.hpp>
-#include <HyperSonicDrivers/audio/stubs/StubMixer.hpp>
-#include <HyperSonicDrivers/hardware/opl/OplEmulator.hpp>
 #include <HyperSonicDrivers/hardware/opl/OplType.hpp>
-#include <HyperSonicDrivers/files/dmx/OP2File.hpp>
 #include <HyperSonicDrivers/hardware/opl/OPLFactory.hpp>
 
 namespace HyperSonicDrivers::drivers::midi::devices
 {
-    using audio::stubs::StubMixer;
-    using hardware::opl::OplType;
-    using hardware::opl::OplEmulator;
-    using hardware::opl::OPLFactory;
-    using files::dmx::OP2File;
-    using audio::mixer::eChannelGroup;
-
-    const std::string GENMIDI_OP2 = std::string("../fixtures/GENMIDI.OP2");
-
     TEST(SbPro2, cstor_)
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(auto s = SbPro2(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(auto s = SbPro2(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 
-    class SbPro2Emulator_ : public ::testing::TestWithParam<std::tuple<hardware::opl::OplEmulator, bool>>
-    {
-    public:
-        const OplEmulator oplEmu = std::get<0>(GetParam());
-        const bool shouldThrow = std::get<1>(GetParam());
-        const OP2File op2File = OP2File(GENMIDI_OP2);
-        const std::shared_ptr<StubMixer> mixer = std::make_shared<StubMixer>();
-
-    };
+    class SbPro2Emulator_ : public EmulatorTestCase<SbPro2> {};
+    
     TEST_P(SbPro2Emulator_, cstr_TYPE)
     {
-        if (this->shouldThrow) {
-            EXPECT_THROW(
-                devices::SbPro2(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu),
-                std::runtime_error
-            );
-        }
-        else {
-            EXPECT_NO_THROW(devices::SbPro2(this->mixer, eChannelGroup::Plain, 255, 0, this->op2File.getBank(), this->oplEmu));
-        }
+        test_case();
     }
+
     INSTANTIATE_TEST_SUITE_P(
         SbPro2,
         SbPro2Emulator_,
@@ -63,7 +37,7 @@ namespace HyperSonicDrivers::drivers::midi::devices
     {
         auto op2File = OP2File(GENMIDI_OP2);
         auto mixer = std::make_shared<StubMixer>();
-        EXPECT_NO_THROW(SbPro2(mixer, eChannelGroup::Plain, 255, 0, op2File.getBank()));
+        EXPECT_NO_THROW(SbPro2(mixer, op2File.getBank(), eChannelGroup::Plain));
     }
 }
 

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/westwood/TestADLDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/drivers/westwood/TestADLDriver.cpp
@@ -20,7 +20,8 @@ namespace HyperSonicDrivers::drivers::westwood
         EXPECT_EQ(opl.use_count(), 1);
         EXPECT_EQ(mixer.use_count(), 2);
 
-        ADLDriver adlDrv(opl, adlFile);
+        ADLDriver adlDrv(opl, audio::mixer::eChannelGroup::Plain);
+        adlDrv.setADLFile(adlFile);
         EXPECT_EQ(opl.use_count(), 2);
         EXPECT_EQ(adlFile.use_count(), 2);
     }
@@ -37,7 +38,8 @@ namespace HyperSonicDrivers::drivers::westwood
         EXPECT_EQ(opl.use_count(), 1);
         EXPECT_EQ(mixer.use_count(), 2);
 
-        auto adlDrv = std::make_shared<ADLDriver>(opl, adlFile);
+        auto adlDrv = std::make_shared<ADLDriver>(opl, audio::mixer::eChannelGroup::Plain);
+        adlDrv->setADLFile(adlFile);
         EXPECT_EQ(adlDrv.use_count(), 1);
         EXPECT_EQ(opl.use_count(), 2);
         EXPECT_EQ(adlFile.use_count(), 2);

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/hardware/opl/OPLMock.hpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/hardware/opl/OPLMock.hpp
@@ -10,13 +10,19 @@ namespace HyperSonicDrivers::hardware::opl
     {
     public:
         OPLMock() : OPL(OplType::OPL2) {}
-        bool init() override { _init = true; return true; }
+        bool init() override { m_init = true; return true; }
         void reset() override {};
         void write(const uint32_t port, const uint16_t val) noexcept override {};
         uint8_t read(const uint32_t port) noexcept override { return 0; };
         void writeReg(const uint16_t r, const uint16_t v) noexcept override {};
         uint32_t setCallbackFrequency(int timerFrequency) override { return 1; }
-        void startCallbacks(int timerFrequency) override {};
+        void startCallbacks(
+            const audio::mixer::eChannelGroup group,
+            const uint8_t volume,
+            const uint8_t pan,
+            const int timerFrequency
+        ) override {};
         void stopCallbacks() override {};
+
     };
 }

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/utils/TestEndianness.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/utils/TestEndianness.cpp
@@ -24,18 +24,18 @@ namespace HyperSonicDrivers::utils
         EXPECT_EQ(swapBE32(0x000000A0), 0xA0000000);
     }
 
-    TEST(Endianness, READ_LE_UINT16)
+    TEST(Endianness, readLE_uint16)
     {
         uint16_t i = 1;
         const void* ptr = &i;
-        EXPECT_EQ(READ_LE_UINT16(ptr), swapLE16(i));
+        EXPECT_EQ(readLE_uint16(ptr), swapLE16(i));
     }
 
-    TEST(Endianness, READ_BE_UINT16)
+    TEST(Endianness, readBE_uint16)
     {
         uint16_t i = 1;
         const void* ptr = &i;
-        EXPECT_EQ(READ_BE_UINT16(ptr), swapBE16(i));
+        EXPECT_EQ(readBE_uint16(ptr), swapBE16(i));
     }
 }
 


### PR DESCRIPTION
- [x] OPL2instrument_t looks not includable for client of the lib. because .h file are not included in the install cmake part
- [x] mixer master volume setting is missing.
- [x] ~sdl audio driver option is missing, it's just using automatically, but there could be more then one it looks~ (it must be set before calling SDL_Init, quite annoying, also a small test with `"directsound"` drivers only NukedOPL was working, not worth doing it at the moment.)
- [x] reverseStereo flag not everywhere available, it should be a mixer flag
- [x] opl emulated using groupchannel is hardcoded to plain, it requires to choose which one is. So creating multiple opl operator can be dedicated to sfx and music
- [ ] ~#249~
- [ ] ~midi:devices move to devices that embedd the MIDDriver and ADLDriver for now and have a overloadede play method to play from the device, simpler to use.~
