### PR TITLE
PCMDriver forward tracks being played

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,15 +18,15 @@ on:
     #branches:
     #  - master
 
-  #pull_request:
-  ##  branches: [ master ]
-  #  paths-ignore:
-  #    - 'doc/**'
-  #    - '.gitignore'
-  #    - '.gitattributes'
-  #    - 'README.md'
-  #    - 'LICENSE'
-  #    - 'wave_generators.r'
+  pull_request:
+  #  branches: [ master ]
+    paths-ignore:
+      - 'doc/**'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'README.md'
+      - 'LICENSE'
+      - 'wave_generators.r'
 
 #permissions: read-all
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 
-project ("sdl2-hyper-sonic-drivers" VERSION 0.16.0 DESCRIPTION "SDL2 based Hyper-Sonic Drivers for emulating old soundcards")
+project ("sdl2-hyper-sonic-drivers" VERSION 0.17.0 DESCRIPTION "SDL2 based Hyper-Sonic Drivers for emulating old soundcards")
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IAudioStream.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IAudioStream.hpp
@@ -23,5 +23,6 @@ namespace HyperSonicDrivers::audio
         virtual uint32_t getRate() const = 0;
         virtual bool endOfData() const = 0;
         virtual bool isEnded() const { return endOfData(); }
+        //virtual void forward(const uint32_t ms) = 0;
     };
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IAudioStream.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/IAudioStream.hpp
@@ -23,6 +23,5 @@ namespace HyperSonicDrivers::audio
         virtual uint32_t getRate() const = 0;
         virtual bool endOfData() const = 0;
         virtual bool isEnded() const { return endOfData(); }
-        //virtual void forward(const uint32_t ms) = 0;
     };
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/PCMSound.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/PCMSound.hpp
@@ -27,8 +27,6 @@ namespace HyperSonicDrivers::audio
             const std::shared_ptr<int16_t[]> &data
         );
 
-        bool append(const PCMSound* sound2) noexcept;
-
         const mixer::eChannelGroup group;
         const bool stereo;
         const uint32_t freq;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.cpp
@@ -38,6 +38,12 @@ namespace HyperSonicDrivers::audio::streams
         return m_curPos == m_sound->dataSize;
     }
 
+    void PCMStream::forward(const uint32_t bytes) noexcept
+    {
+        m_curPos += bytes;
+        m_curPos = std::min(m_curPos, m_sound->dataSize);
+    }
+
     std::shared_ptr<PCMSound> PCMStream::getSound() const noexcept
     {
         return m_sound;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.hpp
@@ -19,6 +19,7 @@ namespace HyperSonicDrivers::audio::streams
         bool endOfData() const override;
 
         void forward(const uint32_t bytes) noexcept;
+
         std::shared_ptr<PCMSound>  getSound() const noexcept;
     private:
         std::shared_ptr<PCMSound> m_sound;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/audio/streams/PCMStream.hpp
@@ -18,6 +18,7 @@ namespace HyperSonicDrivers::audio::streams
         uint32_t getRate() const override;
         bool endOfData() const override;
 
+        void forward(const uint32_t bytes) noexcept;
         std::shared_ptr<PCMSound>  getSound() const noexcept;
     private:
         std::shared_ptr<PCMSound> m_sound;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -105,6 +105,16 @@ namespace HyperSonicDrivers::drivers
             stream->forward(utils::ms_toPos(ms, stream->getSound()));
     }
 
+    void PCMDriver::forward(const uint32_t ms, audio::mixer::eChannelGroup group) const noexcept
+    {
+        for (const auto& [stream, _] : m_PCMStreams_channels)
+        {
+            const auto& s = stream->getSound();
+            if (s->group == group)
+                stream->forward(utils::ms_toPos(ms, s));
+        }
+    }
+
     void PCMDriver::releaseEndedStreams_() noexcept
     {
         for (auto it = m_PCMStreams_channels.begin(); it != m_PCMStreams_channels.end();)

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -105,13 +105,24 @@ namespace HyperSonicDrivers::drivers
             stream->forward(utils::ms_toPos(ms, stream->getSound()));
     }
 
-    void PCMDriver::forward(const uint32_t ms, audio::mixer::eChannelGroup group) const noexcept
+    void PCMDriver::forward(const uint32_t ms, const audio::mixer::eChannelGroup group) const noexcept
     {
         for (const auto& [stream, _] : m_PCMStreams_channels)
         {
             const auto& s = stream->getSound();
             if (s->group == group)
                 stream->forward(utils::ms_toPos(ms, s));
+        }
+    }
+
+    void PCMDriver::forward(const uint32_t ms, const uint8_t channel_id) const noexcept
+    {
+        for (const auto& [stream, ch_id] : m_PCMStreams_channels)
+        {
+            if (ch_id != channel_id)
+                continue;
+
+            stream->forward(utils::ms_toPos(ms, stream->getSound()));
         }
     }
 

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <HyperSonicDrivers/drivers/PCMDriver.hpp>
+#include <HyperSonicDrivers/utils/sound.hpp>
 
 namespace HyperSonicDrivers::drivers
 {
@@ -96,6 +97,12 @@ namespace HyperSonicDrivers::drivers
             stop(ch_id, false);
 
         releaseStreams_();
+    }
+
+    void PCMDriver::forward(const uint32_t ms) noexcept
+    {
+        for (const auto& [stream, _] : m_PCMStreams_channels)
+            stream->forward(utils::ms_toPos(ms, stream->getSound()));
     }
 
     void PCMDriver::releaseEndedStreams_() noexcept

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.cpp
@@ -99,7 +99,7 @@ namespace HyperSonicDrivers::drivers
         releaseStreams_();
     }
 
-    void PCMDriver::forward(const uint32_t ms) noexcept
+    void PCMDriver::forward(const uint32_t ms) const noexcept
     {
         for (const auto& [stream, _] : m_PCMStreams_channels)
             stream->forward(utils::ms_toPos(ms, stream->getSound()));

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
@@ -35,6 +35,7 @@ namespace HyperSonicDrivers::drivers
         void stop() noexcept;
 
         void forward(const uint32_t ms) const noexcept;
+        void forward(const uint32_t ms, audio::mixer::eChannelGroup group) const noexcept;
 
         const uint8_t max_streams;
     private:

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
@@ -34,7 +34,7 @@ namespace HyperSonicDrivers::drivers
         void stop(const std::shared_ptr<audio::PCMSound>& sound, const bool releaseEndedStreams = true);
         void stop() noexcept;
 
-        void forward(const uint32_t ms) noexcept;
+        void forward(const uint32_t ms) const noexcept;
 
         const uint8_t max_streams;
     private:

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
@@ -34,6 +34,8 @@ namespace HyperSonicDrivers::drivers
         void stop(const std::shared_ptr<audio::PCMSound>& sound, const bool releaseEndedStreams = true);
         void stop() noexcept;
 
+        void forward(const uint32_t ms) noexcept;
+
         const uint8_t max_streams;
     private:
         std::shared_ptr<audio::IMixer> m_mixer;

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/drivers/PCMDriver.hpp
@@ -35,7 +35,8 @@ namespace HyperSonicDrivers::drivers
         void stop() noexcept;
 
         void forward(const uint32_t ms) const noexcept;
-        void forward(const uint32_t ms, audio::mixer::eChannelGroup group) const noexcept;
+        void forward(const uint32_t ms, const audio::mixer::eChannelGroup group) const noexcept;
+        void forward(const uint32_t ms, const uint8_t channel_id) const noexcept;
 
         const uint8_t max_streams;
     private:

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.cpp
@@ -71,4 +71,14 @@ namespace HyperSonicDrivers::utils
 
         return  ms * 1000 / sound->freq;
     }
+
+    uint32_t ms_toPos(const uint32_t ms, const std::shared_ptr<audio::PCMSound>& sound)
+    {
+        uint32_t res = ms * sound->freq / 1000;
+
+        if (sound->stereo)
+            res <<= 1;
+
+        return res;
+    }
 }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.cpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.cpp
@@ -67,7 +67,7 @@ namespace HyperSonicDrivers::utils
         uint32_t ms = sound->dataSize;
 
         if (sound->stereo)
-            ms /= 2;
+            ms >>= 1;
 
         return  ms * 1000 / sound->freq;
     }

--- a/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.hpp
+++ b/sdl2-hyper-sonic-drivers/src/HyperSonicDrivers/utils/sound.hpp
@@ -26,4 +26,5 @@ namespace HyperSonicDrivers::utils
         const std::shared_ptr<audio::PCMSound>& sound2);
 
     uint32_t duration_ms(const std::shared_ptr<audio::PCMSound>& sound);
+    uint32_t ms_toPos(const uint32_t, const std::shared_ptr<audio::PCMSound>& sound);
 }

--- a/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/utils/TestSound.cpp
+++ b/sdl2-hyper-sonic-drivers/test/HyperSonicDrivers/utils/TestSound.cpp
@@ -81,6 +81,28 @@ namespace HyperSonicDrivers::utils
         EXPECT_EQ(duration_ms(s4), 11025);
         EXPECT_EQ(duration_ms(s5), 5512);
     }
+
+    TEST(utils, ms_toPos)
+    {
+        const uint32_t size = 44100 * 2;
+        auto data = std::make_shared<int16_t[]>(size);
+
+        auto s1 = std::make_shared<PCMSound>(eChannelGroup::Plain, true, 44100, size, data);
+
+        EXPECT_EQ(ms_toPos(0, s1), 0);
+        EXPECT_EQ(ms_toPos(1000, s1), 44100 * 2);
+        EXPECT_EQ(ms_toPos(500, s1), 22050 * 2);
+        EXPECT_EQ(ms_toPos(250, s1), 11025 * 2);
+        EXPECT_EQ(ms_toPos(100, s1), 4410 * 2);
+
+        auto s2 = std::make_shared<PCMSound>(eChannelGroup::Plain, false, 44100, size, data);
+
+        EXPECT_EQ(ms_toPos(0, s2), 0);
+        EXPECT_EQ(ms_toPos(1000, s2), 44100);
+        EXPECT_EQ(ms_toPos(500, s2), 22050);
+        EXPECT_EQ(ms_toPos(250, s2), 11025);
+        EXPECT_EQ(ms_toPos(100, s2), 4410);
+    }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
- [x] forward is it more than the total duration it will end the track
- [ ] get "current time" (so it can be used to know how much to skip)
- [ ] ~rewind if it is more than the beginning it will just from the beginning~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a 'forward' function to enhance audio stream navigation.
	- Added a 'ms_toPos' function to calculate position in sound data.
- **Bug Fixes**
	- Optimized stereo sound data calculation by replacing division operation with bitwise right shift.
- **Tests**
	- Added a new test case 'ms_toPos' to verify the functionality of the new function.
- **Chores**
	- Updated the project version from 0.16.0 to 0.17.0.
	- Modified GitHub Actions workflow to exclude specific files and directories from triggering the workflow on pull requests.
- **Refactor**
	- Removed the 'append' function from the 'PCMSound' class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->